### PR TITLE
Histograms

### DIFF
--- a/data/datamodules.py
+++ b/data/datamodules.py
@@ -32,6 +32,7 @@ class ZincDatamodule(pytorch_lightning.LightningDataModule):
         self.data.generate_conformations()
         self.batch_size = batch_size
         self.num_workers = dataloader_num_workers
+        self.featurizer = featurizer
 
     def train_dataloader(self) -> torch.utils.data.DataLoader:
         """

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 pandas==2.2.2
-pillow==10.0.1
+pillow==10.3.0
 matplotlib==3.8.0
 torch==2.3.0
 rdkit==2023.9.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,6 @@
 pandas==2.2.2
+pillow==10.0.1
+matplotlib==3.8.0
 torch==2.3.0
 rdkit==2023.9.5
 tqdm==4.66.2

--- a/spiff/experiments.py
+++ b/spiff/experiments.py
@@ -116,7 +116,7 @@ class SPiFFModule(pytorch_lightning.LightningModule):
 
             labels = [
                 "{:.2f}".format(bin_label.item())
-                for bin_label in self.hist_metric.bins[-1]
+                for bin_label in self.hist_metric.bins[:-1]
             ]
 
             plt.bar(labels, hist.cpu().numpy())

--- a/spiff/experiments.py
+++ b/spiff/experiments.py
@@ -112,7 +112,7 @@ class SPiFFModule(pytorch_lightning.LightningModule):
             hist = self.hist_metric.compute()
             hist /= torch.sum(hist)  # normalize to [0.1]
 
-            fig, ax = plt.figure()
+            fig, ax = plt.subplots()
 
             labels = [
                 "{:.2f}".format(bin_label.item())

--- a/spiff/experiments.py
+++ b/spiff/experiments.py
@@ -14,6 +14,7 @@ from spiff.models import SPiFF
 from spiff.utils import figure_to_wandb
 
 logger = logging.getLogger(__name__)
+plt.set_loglevel("WARNING")
 
 
 class SPiFFModule(pytorch_lightning.LightningModule):

--- a/spiff/experiments.py
+++ b/spiff/experiments.py
@@ -1,16 +1,17 @@
 import logging
 from typing import Any, Callable, Dict, List, Optional, Union
 
+import matplotlib.pyplot as plt
 import pytorch_lightning
 import torch
 import torch_geometric.data.batch
-import wandb
 from pytorch_lightning.utilities.types import OptimizerLRScheduler
 
 from data.featurizer import Featurizer, GraphFeaturizerFactory
 from spiff.metrics import Histogram
 from spiff.mining import TripletMiner
 from spiff.models import SPiFF
+from spiff.utils import figure_to_wandb
 
 logger = logging.getLogger(__name__)
 
@@ -110,19 +111,23 @@ class SPiFFModule(pytorch_lightning.LightningModule):
             wandb_logger = self.logger.experiment  # type: ignore
             hist = self.hist_metric.compute()
             hist /= torch.sum(hist)  # normalize to [0.1]
-            data = [
-                [str(bin_label.item()), bin_val]
-                for bin_label, bin_val in zip(self.hist_metric.bins, hist)
+
+            fig, ax = plt.figure()
+
+            labels = [
+                "{:.2f}".format(bin_label.item())
+                for bin_label in self.hist_metric.bins[-1]
             ]
-            table = wandb.Table(data=data, columns=["bin", "probability"])
+
+            plt.bar(labels, hist.cpu().numpy())
+            ax.set_ylabel("probability")
+            ax.set_title("Similarity Distribution")
+
             wandb_logger.log(
-                {
-                    "histogram": wandb.plot.bar(
-                        table, "bin", "probability", title="Similarity Distribution"
-                    )
-                },
-                step=self.current_epoch,
+                {"histogram": figure_to_wandb(fig)}, step=self.current_epoch
             )
+
+            plt.close(fig)
 
         self.hist_metric.reset()
 

--- a/spiff/utils.py
+++ b/spiff/utils.py
@@ -1,4 +1,9 @@
+import io
 from typing import Iterable, Iterator, Tuple, TypeVar
+
+import matplotlib.figure
+import wandb
+from PIL import Image
 
 T = TypeVar("T")
 
@@ -13,3 +18,11 @@ def triple_wise(iterable: Iterable[T]) -> Iterator[Tuple[T, T, T]]:
         except StopIteration:
             break
         yield one, two, three
+
+
+def figure_to_wandb(fig: matplotlib.figure.Figure) -> wandb.Image:
+    buffer = io.BytesIO()
+    fig.savefig(buffer, bbox_inches="tight")
+
+    with Image.open(buffer) as img:
+        return wandb.Image(img)


### PR DESCRIPTION
Change Wandb tables to matplotlib histograms, so they can be logged on every epoch.